### PR TITLE
Implementación 5.3. Editar o eliminar calificación propia

### DIFF
--- a/src/TurisGo.Application.Contracts/Calificaciones/CreateCalificacionDto.cs
+++ b/src/TurisGo.Application.Contracts/Calificaciones/CreateCalificacionDto.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace TurisGo.Calificaciones
 {
-    public class CreateUpdateCalificacionDto
+    public class CreateCalificacionDto
     {
         [Required]
         public Guid DestinoId { get; set; }

--- a/src/TurisGo.Application.Contracts/Calificaciones/ICalificacionAppService.cs
+++ b/src/TurisGo.Application.Contracts/Calificaciones/ICalificacionAppService.cs
@@ -8,14 +8,13 @@ using Volo.Abp.Application.Services;
 
 namespace TurisGo.Calificaciones
 {
-    public interface ICalificacionAppService : 
-        ICrudAppService
-        <
-        CalificacionDto,
-        Guid,
-        PagedAndSortedResultRequestDto,
-        CreateUpdateCalificacionDto
-        >
+    public interface ICalificacionAppService : IApplicationService
     {
+        Task<CalificacionDto> CreateAsync(CreateCalificacionDto input);
+        Task<CalificacionDto> UpdateAsync(Guid id, UpdateCalificacionDto input);
+        Task<CalificacionDto> GetAsync(Guid id);
+        Task<PagedResultDto<CalificacionDto>> GetListAsync(PagedAndSortedResultRequestDto input);
+
+        Task DeleteAsync(Guid id);
     }
 }

--- a/src/TurisGo.Application.Contracts/Calificaciones/UpdateCalificacionDto.cs
+++ b/src/TurisGo.Application.Contracts/Calificaciones/UpdateCalificacionDto.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TurisGo.Calificaciones
+{
+    public class UpdateCalificacionDto
+    {
+        [Required]
+        [Range(1,5,ErrorMessage ="La puntuación debe estar entre 1 y 5.")]
+        public int Puntuacion {  get; set; }
+
+        [MaxLength(1000)]
+        public string? Comentario { get; set; }
+    }
+}

--- a/src/TurisGo.Application/Calificaciones/CalificacionAppService.cs
+++ b/src/TurisGo.Application/Calificaciones/CalificacionAppService.cs
@@ -17,29 +17,21 @@ using Volo.Abp.Validation;
 namespace TurisGo.Calificaciones
 {
    [Authorize] //Exige token
-    public class CalificacionAppService :
-        CrudAppService
-        <
-          Calificacion,
-          CalificacionDto,
-          Guid,
-          PagedAndSortedResultRequestDto,
-          CreateUpdateCalificacionDto
-        >,
-        ICalificacionAppService
+    public class CalificacionAppService : ApplicationService, ICalificacionAppService
     {
         private readonly ICurrentUser _currentUser;
+        private readonly IRepository<Calificacion, Guid> _repository;
 
         public CalificacionAppService(
             IRepository<Calificacion, Guid> repository,                                  
-            ICurrentUser currentUser) 
-            : base(repository)
+            ICurrentUser currentUser)
         {
-            _currentUser = currentUser;                          
+            _currentUser = currentUser;   
+            _repository = repository;
         }
 
 
-        public override async Task<CalificacionDto> CreateAsync(CreateUpdateCalificacionDto input)
+        public async Task<CalificacionDto> CreateAsync(CreateCalificacionDto input)
         {
             if (!_currentUser.IsAuthenticated)
                 throw new UnauthorizedAccessException("Debe estar autenticado para calificar un destino.");
@@ -47,7 +39,7 @@ namespace TurisGo.Calificaciones
             var userId = _currentUser.Id!.Value;
 
             // Verificar si el usuario ya califico anteriormente
-            var yaCalifico = await Repository.FirstOrDefaultAsync(x =>
+            var yaCalifico = await _repository.FirstOrDefaultAsync(x =>
                 x.DestinoId == input.DestinoId &&
                 x.UserId == userId);
 
@@ -63,8 +55,76 @@ namespace TurisGo.Calificaciones
                 input.Comentario
             );
 
-            var calificacionCreada = await Repository.InsertAsync(calificacion, autoSave: true);
+            var calificacionCreada = await _repository.InsertAsync(calificacion, autoSave: true);
             return ObjectMapper.Map<Calificacion, CalificacionDto>(calificacionCreada);
         }
+
+        public async Task<CalificacionDto> GetAsync(Guid id)
+        {
+            var calificacion = await _repository.GetAsync(id);
+            return ObjectMapper.Map<Calificacion, CalificacionDto>(calificacion);
+        }
+
+        public async Task<PagedResultDto<CalificacionDto>> GetListAsync(PagedAndSortedResultRequestDto input)
+        {
+            var queryable = await _repository.GetQueryableAsync();
+
+            var query = queryable
+                .OrderByDescending(x => x.CreationTime)
+                .Skip(input.SkipCount)
+                .Take(input.MaxResultCount);
+
+            var totalCount = await AsyncExecuter.CountAsync(queryable);
+            var calificaciones = await AsyncExecuter.ToListAsync(query);
+
+            return new PagedResultDto<CalificacionDto>(
+                totalCount,
+                ObjectMapper.Map<List<Calificacion>, List<CalificacionDto>>(calificaciones)
+            );
+        }
+
+        public async Task <CalificacionDto> UpdateAsync(Guid id, UpdateCalificacionDto input)
+        {
+
+            if (!_currentUser.IsAuthenticated)
+                throw new UnauthorizedAccessException("Debe estar autenticado para actualizar!");
+
+            var userId = _currentUser.Id!.Value;
+
+            // Buscar la calificacion
+            var calificacion = await _repository.GetAsync(id);
+
+            if (calificacion.UserId != userId)
+                throw new AbpAuthorizationException("No tiene permisos para editar esta calificación.");
+
+            // Actualizar los datos
+            calificacion.SetPuntuacion(input.Puntuacion);
+            calificacion.SetComentario(input.Comentario);
+
+            // Guardar cambios
+            var calificacionAutualizada = await _repository.UpdateAsync(calificacion, autoSave: true);
+            return ObjectMapper.Map<Calificacion, CalificacionDto>(calificacionAutualizada);
+
+        }
+
+        public async Task DeleteAsync(Guid id)
+        {
+            if (!_currentUser.IsAuthenticated)
+                throw new UnauthorizedAccessException("Debe estar autenticado para eliminar una calificación");
+
+            var userId = _currentUser.Id!.Value;
+
+            // Buscar la calificacion
+            var calificacion = await _repository.GetAsync(id);
+
+            // Verificar que la calificacion pertenece al usuario actual
+            if (calificacion.UserId != userId)
+                throw new AbpAuthorizationException("No tiene permisos para eliminar esta calificación");
+
+            // Eliminar la calificacion
+            await _repository.DeleteAsync(id, autoSave: true);
+        }
+
+        
     }
 }

--- a/src/TurisGo.Application/TurisGoApplicationAutoMapperProfile.cs
+++ b/src/TurisGo.Application/TurisGoApplicationAutoMapperProfile.cs
@@ -19,6 +19,6 @@ public class TurisGoApplicationAutoMapperProfile : Profile
         CreateMap<Coordenada, CoordenadaDto>().ReverseMap();
 
         CreateMap<Calificacion,CalificacionDto>();
-        CreateMap<CreateUpdateCalificacionDto, Calificacion>();     
+        CreateMap<CreateCalificacionDto, Calificacion>();     
     }
 }

--- a/src/TurisGo.Domain/Calificaciones/Calificacion.cs
+++ b/src/TurisGo.Domain/Calificaciones/Calificacion.cs
@@ -19,13 +19,13 @@ namespace TurisGo.Calificaciones
 
         public Calificacion(Guid id, Guid destinoId, Guid usuarioId, int puntuacion, string comentario) : base(id)
         {
-            SetPutuacion(puntuacion);
+            SetPuntuacion(puntuacion);
             SetComentario(comentario);
             SetDestino(destinoId);
             SetUser(usuarioId);
         }
 
-        public void SetPutuacion(int puntuacion)
+        public void SetPuntuacion(int puntuacion)
         {
             if (puntuacion < 1 || puntuacion > 5)
             {
@@ -67,8 +67,5 @@ namespace TurisGo.Calificaciones
 
             UserId = IdUser;
         }
-
-
-
     }
 }

--- a/test/TurisGo.Application.Tests/Calificaciones/CalificacionAppService_IntegrationTest.cs
+++ b/test/TurisGo.Application.Tests/Calificaciones/CalificacionAppService_IntegrationTest.cs
@@ -86,7 +86,7 @@ namespace TurisGo.Calificaciones
         {
             using (UseAnonymous())
             {
-                var input = new CreateUpdateCalificacionDto
+                var input = new CreateCalificacionDto
                 {
                     DestinoId = Guid.NewGuid(),
                     Puntuacion = 5,
@@ -104,6 +104,34 @@ namespace TurisGo.Calificaciones
         }
 
         [Fact]
+        public async Task Should_Not_Allow_Duplicate_Rating_For_Same_Destino()
+        {
+            var user = Guid.NewGuid();
+            var destinoId = await CrearDestinoAsync("Londres");
+
+            using (UseUser(user, "user"))
+            {
+                // Primera calificación - OK
+                await _calificaciones.CreateAsync(new CreateCalificacionDto
+                {
+                    DestinoId = destinoId,
+                    Puntuacion = 5,
+                    Comentario = "Primera"
+                });
+
+                // Segunda calificación mismo destino - DEBE FALLAR
+                await Should.ThrowAsync<AbpValidationException>(async () =>
+                    await _calificaciones.CreateAsync(new CreateCalificacionDto
+                    {
+                        DestinoId = destinoId,
+                        Puntuacion = 4,
+                        Comentario = "Intento duplicado"
+                    })
+                );
+            }
+        }
+
+        [Fact]
         public async Task Should_Filter_Ratings_By_Current_User()
         {
             var user1 = Guid.NewGuid();
@@ -116,12 +144,12 @@ namespace TurisGo.Calificaciones
                 d1_user1 = await CrearDestinoAsync("Tokio");
                 d2_user1 = await CrearDestinoAsync("Paris");
 
-                await _calificaciones.CreateAsync(new CreateUpdateCalificacionDto { 
+                await _calificaciones.CreateAsync(new CreateCalificacionDto { 
                     DestinoId = d1_user1, 
                     Puntuacion = 5, 
                     Comentario = "A" });
 
-                await _calificaciones.CreateAsync(new CreateUpdateCalificacionDto { 
+                await _calificaciones.CreateAsync(new CreateCalificacionDto { 
                     DestinoId = d2_user1, 
                     Puntuacion = 4, 
                     Comentario = "B" });
@@ -130,7 +158,7 @@ namespace TurisGo.Calificaciones
             using (UseUser(user2, "user2"))
             {
                 d1_user2 = await CrearDestinoAsync("Roma");
-                await _calificaciones.CreateAsync(new CreateUpdateCalificacionDto {
+                await _calificaciones.CreateAsync(new CreateCalificacionDto {
                     DestinoId = d1_user2, 
                     Puntuacion = 2, 
                     Comentario = "C" });
@@ -163,20 +191,21 @@ namespace TurisGo.Calificaciones
 
             using (UseUser(user, "user"))
             {
-                califId = (await _calificaciones.CreateAsync(new CreateUpdateCalificacionDto
+                califId = (await _calificaciones.CreateAsync(new CreateCalificacionDto
                 {
                     DestinoId = destinoId,
                     Puntuacion = 3,
                     Comentario = "Original"
                 })).Id;
 
-                var updated = await _calificaciones.UpdateAsync(califId, new CreateUpdateCalificacionDto
+                // Usar UpdateCalificacionDto en lugar de CreateCalificacionDto
+                var updated = await _calificaciones.UpdateAsync(califId, new UpdateCalificacionDto
                 {
-                    DestinoId = destinoId,
                     Puntuacion = 5,
                     Comentario = "Edit"
                 });
                 updated.Puntuacion.ShouldBe(5);
+                updated.Comentario.ShouldBe("Edit");
 
                 await _calificaciones.DeleteAsync(califId);
 
@@ -184,6 +213,65 @@ namespace TurisGo.Calificaciones
                 list.Items.Any(i => i.Id == califId).ShouldBeFalse();
             }
         }
+
+        // Verificar que NO se puede actualizar calificación ajena
+        [Fact]
+        public async Task Should_Not_Allow_Update_Other_User_Rating()
+        {
+            var user1 = Guid.NewGuid();
+            var user2 = Guid.NewGuid();
+            var destinoId = await CrearDestinoAsync("Berlin");
+            Guid califId;
+
+            using (UseUser(user1, "user1"))
+            {
+                califId = (await _calificaciones.CreateAsync(new CreateCalificacionDto
+                {
+                    DestinoId = destinoId,
+                    Puntuacion = 4,
+                    Comentario = "De user1"
+                })).Id;
+            }
+
+            using (UseUser(user2, "user2"))
+            {
+                await Should.ThrowAsync<EntityNotFoundException>(async () =>
+                    await _calificaciones.UpdateAsync(califId, new UpdateCalificacionDto
+                    {
+                        Puntuacion = 1,
+                        Comentario = "Intento de user2"
+                    })
+                );
+            }
+        }
+
+        // Verificar que NO se puede eliminar calificación ajena
+        [Fact]
+        public async Task Should_Not_Allow_Delete_Other_User_Rating()
+        {
+            var user1 = Guid.NewGuid();
+            var user2 = Guid.NewGuid();
+            var destinoId = await CrearDestinoAsync("Ámsterdam");
+            Guid califId;
+
+            using (UseUser(user1, "user1"))
+            {
+                califId = (await _calificaciones.CreateAsync(new CreateCalificacionDto
+                {
+                    DestinoId = destinoId,
+                    Puntuacion = 5,
+                    Comentario = "De user1"
+                })).Id;
+            }
+
+            using (UseUser(user2, "user2"))
+            {
+                await Should.ThrowAsync<EntityNotFoundException>(async () =>
+                    await _calificaciones.DeleteAsync(califId)
+                );
+            }
+        }
+
 
         [Fact]
         public async Task Should_Throw_When_Rating_Out_Of_Range()
@@ -194,12 +282,72 @@ namespace TurisGo.Calificaciones
             using (UseUser(user, "user"))
             {
                 await Should.ThrowAsync<AbpValidationException>(() =>
-                    _calificaciones.CreateAsync(new CreateUpdateCalificacionDto
+                    _calificaciones.CreateAsync(new CreateCalificacionDto
                     {
                         DestinoId = destinoId,
                         Puntuacion = 999,
                         Comentario = "invalid"
                     }));
+            }
+        }
+
+        // ← NUEVA: Verificar autenticación en Update
+        [Fact]
+        public async Task Should_Require_Authentication_On_Update()
+        {
+            var user = Guid.NewGuid();
+            var destinoId = await CrearDestinoAsync("Milán");
+            Guid califId;
+
+            using (UseUser(user, "user"))
+            {
+                califId = (await _calificaciones.CreateAsync(new CreateCalificacionDto
+                {
+                    DestinoId = destinoId,
+                    Puntuacion = 3,
+                    Comentario = "Original"
+                })).Id;
+            }
+
+            using (UseAnonymous())
+            {
+                var ex = await Should.ThrowAsync<Exception>(async () =>
+                    await _calificaciones.UpdateAsync(califId, new UpdateCalificacionDto
+                    {
+                        Puntuacion = 5,
+                        Comentario = "Intento"
+                    })
+                );
+
+                (ex is AbpAuthorizationException || ex is UnauthorizedAccessException).ShouldBeTrue();
+            }
+        }
+
+        // Verificar autenticación en Delete
+        [Fact]
+        public async Task Should_Require_Authentication_On_Delete()
+        {
+            var user = Guid.NewGuid();
+            var destinoId = await CrearDestinoAsync("Florencia");
+            Guid califId;
+
+            using (UseUser(user, "user"))
+            {
+                califId = (await _calificaciones.CreateAsync(new CreateCalificacionDto
+                {
+                    DestinoId = destinoId,
+                    Puntuacion = 4,
+                    Comentario = "Original"
+                })).Id;
+            }
+
+            using (UseAnonymous())
+            {
+                var ex = await Should.ThrowAsync<Exception>(async () =>
+                    await _calificaciones.DeleteAsync(califId)
+                );
+
+                (ex is AbpAuthorizationException || ex is UnauthorizedAccessException).ShouldBeTrue();
             }
         }
 

--- a/test/TurisGo.Domain.Tests/Calificaciones/Calificacion_Tests.cs
+++ b/test/TurisGo.Domain.Tests/Calificaciones/Calificacion_Tests.cs
@@ -13,13 +13,11 @@ namespace TurisGo.Calificaciones
         private readonly Guid _userId = Guid.NewGuid();
         private readonly Guid _destinoId = Guid.NewGuid();
 
-
         [Fact]
         public void Should_Create_Calificacion_With_Valid_Data()
         {
             //Arrange
             var id = Guid.NewGuid();
-
             //Act
             var calificacion = new Calificacion(
                 id,
@@ -27,28 +25,53 @@ namespace TurisGo.Calificaciones
                 _userId,
                 5,
                 "Excelente destino"
-                );
-
+            );
             //Assert
             calificacion.Id.ShouldBe(id);
             calificacion.DestinoId.ShouldBe(_destinoId);
+            calificacion.UserId.ShouldBe(_userId); // ← Agregar esta validación
             calificacion.Puntuacion.ShouldBe(5);
             calificacion.Comentario.ShouldBe("Excelente destino");
         }
 
-        [Fact]
-        public void Should_Not_Accept_Invalid_Puntuacion()
+        [Theory] // ← Cambiar a Theory para probar múltiples valores
+        [InlineData(0)]
+        [InlineData(6)]
+        [InlineData(-1)]
+        [InlineData(10)]
+        public void Should_Not_Accept_Invalid_Puntuacion(int puntuacionInvalida)
         {
             // Act & Assert
-            Should.Throw<ArgumentException>(() =>
-            new Calificacion(
+            Should.Throw<ArgumentOutOfRangeException>(() => // ← Usar la excepción específica
+                new Calificacion(
+                    Guid.NewGuid(),
+                    _destinoId,
+                    _userId,
+                    puntuacionInvalida,
+                    "test"
+                )
+            );
+        }
+
+        [Theory] // ← Probar todos los valores válidos
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        [InlineData(5)]
+        public void Should_Accept_Valid_Puntuacion(int puntuacionValida)
+        {
+            // Act
+            var calificacion = new Calificacion(
                 Guid.NewGuid(),
                 _destinoId,
                 _userId,
-                6,
+                puntuacionValida,
                 "test"
-                )
             );
+
+            // Assert
+            calificacion.Puntuacion.ShouldBe(puntuacionValida);
         }
 
         [Fact]
@@ -56,7 +79,6 @@ namespace TurisGo.Calificaciones
         {
             //Arrange
             var id = Guid.NewGuid();
-
             //Act
             var calificacion = new Calificacion(
                 id,
@@ -65,28 +87,61 @@ namespace TurisGo.Calificaciones
                 4,
                 null
             );
-
             //Assert
             calificacion.Comentario.ShouldBeNull();
+        }
 
+        [Fact]
+        public void Should_Accept_Comentario_With_Exactly_1000_Characters()
+        {
+            //Arrange
+            var comentario1000 = new string('A', 1000); // Exactamente 1000
+
+            //Act
+            var calificacion = new Calificacion(
+                Guid.NewGuid(),
+                _destinoId,
+                _userId,
+                5,
+                comentario1000
+            );
+
+            //Assert
+            calificacion.Comentario.ShouldBe(comentario1000);
+            calificacion.Comentario.Length.ShouldBe(1000);
         }
 
         [Fact]
         public void Should_Not_Accept_Large_Comentario()
         {
             //Arrange
-            var comentarioLargo = new string('A', 1001); // El limite es 1000
+            var comentarioLargo = new string('A', 1001); // El límite es 1000
 
             //Act & Assert
             Should.Throw<ArgumentException>(() =>
-            new Calificacion(
+                new Calificacion(
+                    Guid.NewGuid(),
+                    _destinoId,
+                    _userId,
+                    5,
+                    comentarioLargo)
+            );
+        }
+
+        [Fact]
+        public void Should_Trim_Comentario_Whitespace()
+        {
+            //Arrange & Act
+            var calificacion = new Calificacion(
                 Guid.NewGuid(),
                 _destinoId,
                 _userId,
-                5,
-                comentarioLargo)  
+                4,
+                "  Comentario con espacios  "
             );
 
+            //Assert
+            calificacion.Comentario.ShouldBe("Comentario con espacios");
         }
 
         [Fact]
@@ -97,15 +152,149 @@ namespace TurisGo.Calificaciones
 
             //Act & Assert
             Should.Throw<ArgumentException>(() =>
-            new Calificacion(
+                new Calificacion(
+                    Guid.NewGuid(),
+                    destinoVacio,
+                    _userId,
+                    5,
+                    "test")
+            );
+        }
+
+        [Fact]
+        public void Should_Not_Accept_UserId_Empty()
+        {
+            //Arrange
+            var userVacio = Guid.Empty;
+
+            //Act & Assert
+            Should.Throw<ArgumentException>(() =>
+                new Calificacion(
+                    Guid.NewGuid(),
+                    _destinoId,
+                    userVacio,
+                    5,
+                    "test")
+            );
+        }
+
+        // ===== PRUEBAS PARA LOS MÉTODOS SetPuntuacion y SetComentario =====
+
+        [Fact]
+        public void Should_Update_Puntuacion_With_Valid_Value()
+        {
+            //Arrange
+            var calificacion = new Calificacion(
                 Guid.NewGuid(),
-                destinoVacio,
+                _destinoId,
                 _userId,
-                5,
-                "test")
+                3,
+                "Comentario inicial"
             );
 
+            //Act
+            calificacion.SetPuntuacion(5);
+
+            //Assert
+            calificacion.Puntuacion.ShouldBe(5);
         }
- 
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(6)]
+        [InlineData(-5)]
+        public void Should_Not_Update_Puntuacion_With_Invalid_Value(int puntuacionInvalida)
+        {
+            //Arrange
+            var calificacion = new Calificacion(
+                Guid.NewGuid(),
+                _destinoId,
+                _userId,
+                3,
+                "Comentario inicial"
+            );
+
+            //Act & Assert
+            Should.Throw<ArgumentOutOfRangeException>(() =>
+                calificacion.SetPuntuacion(puntuacionInvalida)
+            );
+        }
+
+        [Fact]
+        public void Should_Update_Comentario_With_Valid_Value()
+        {
+            //Arrange
+            var calificacion = new Calificacion(
+                Guid.NewGuid(),
+                _destinoId,
+                _userId,
+                4,
+                "Comentario inicial"
+            );
+
+            //Act
+            var nuevoComentario = "Comentario actualizado";
+            calificacion.SetComentario(nuevoComentario);
+
+            //Assert
+            calificacion.Comentario.ShouldBe(nuevoComentario);
+        }
+
+        [Fact]
+        public void Should_Allow_Null_When_Updating_Comentario()
+        {
+            //Arrange
+            var calificacion = new Calificacion(
+                Guid.NewGuid(),
+                _destinoId,
+                _userId,
+                4,
+                "Comentario inicial"
+            );
+
+            //Act
+            calificacion.SetComentario(null);
+
+            //Assert
+            calificacion.Comentario.ShouldBeNull();
+        }
+
+        [Fact]
+        public void Should_Not_Update_Comentario_When_Too_Long()
+        {
+            //Arrange
+            var calificacion = new Calificacion(
+                Guid.NewGuid(),
+                _destinoId,
+                _userId,
+                4,
+                "Comentario inicial"
+            );
+            var comentarioLargo = new string('A', 1001);
+
+            //Act & Assert
+            Should.Throw<ArgumentException>(() =>
+                calificacion.SetComentario(comentarioLargo)
+            );
+        }
+
+        [Fact]
+        public void Should_Trim_Whitespace_When_Updating_Comentario()
+        {
+            //Arrange
+            var calificacion = new Calificacion(
+                Guid.NewGuid(),
+                _destinoId,
+                _userId,
+                4,
+                "Comentario inicial"
+            );
+
+            //Act
+            calificacion.SetComentario("  Nuevo comentario  ");
+
+            //Assert
+            calificacion.Comentario.ShouldBe("Nuevo comentario");
+        }
     }
 }


### PR DESCRIPTION
## Cambios realizados
- Se creó la clase **UpdateCalificacionDto** con los atributos **Comentario** y **Puntuación** para poder realizar la operación.
- Se dejó de heredar de **CRUD** para poder implementar manualmente las operaciones necesarias.
- Se añadieron pruebas de integración y unitarias, resultando exitosas cada una de ellas.
- Se probaron diferentes casos en el endpoint de Swagger

## Issue relacionado
Closes #23 