### PR TITLE
Implementación 4.1. Crear una nueva experiencia en un destino

### DIFF
--- a/src/TurisGo.Application.Contracts/Experiencias/CreateExperienciaDto.cs
+++ b/src/TurisGo.Application.Contracts/Experiencias/CreateExperienciaDto.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TurisGo.Experiencias
+{
+    public class CreateExperienciaDto
+    {
+        [Required]
+        public Guid DestinoId { get; set; }
+
+        [Required]
+        [MaxLength(100, ErrorMessage = "El título no debe superar los 100 caracteres.")]
+        public string Titulo { get; set; }
+
+        [Required]
+        [MaxLength(500, ErrorMessage = "La descripción no debe superar los 500 caracteres.")]
+        public string Descripcion { get; set; }
+
+        [Required]
+        public TipoValoracion Valoracion { get; set; }
+
+    }
+}

--- a/src/TurisGo.Application.Contracts/Experiencias/ExperienciaDto.cs
+++ b/src/TurisGo.Application.Contracts/Experiencias/ExperienciaDto.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Volo.Abp.Application.Dtos;
+
+namespace TurisGo.Experiencias
+{
+    public class ExperienciaDto : AuditedEntityDto<Guid>
+    {
+        public Guid UserId { get; set; }
+        public Guid DestinoId { get; set; }
+        public string Titulo { get; set; }
+        public string Descripcion { get; set; }
+        public TipoValoracion Valoracion { get; set; }
+    }
+}

--- a/src/TurisGo.Application.Contracts/Experiencias/IExperienciaAppService.cs
+++ b/src/TurisGo.Application.Contracts/Experiencias/IExperienciaAppService.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Volo.Abp.Application.Services;
+
+namespace TurisGo.Experiencias
+{
+    public interface IExperienciaAppService : IApplicationService
+    {
+        Task<ExperienciaDto> CreateAsync(CreateExperienciaDto input); // 4.1. Crear una nueva experiencia de un destino.
+    }
+}

--- a/src/TurisGo.Application/Experiencias/ExperienciaAppService.cs
+++ b/src/TurisGo.Application/Experiencias/ExperienciaAppService.cs
@@ -1,0 +1,64 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using System;
+using System.Threading.Tasks;
+using TurisGo.Destinos;
+using Volo.Abp;  
+using Volo.Abp.Application.Services;  
+using Volo.Abp.Domain.Repositories;  
+using Volo.Abp.Validation;
+
+namespace TurisGo.Experiencias
+{
+    [Authorize]
+    public class ExperienciaAppService : ApplicationService, IExperienciaAppService
+    {
+        private readonly IRepository<Experiencia, Guid> _repository;
+        private readonly IRepository<Destino, Guid> _destinoRepository;
+
+        public ExperienciaAppService(
+            IRepository<Experiencia, Guid> repository,
+            IRepository<Destino, Guid> destinoRepository)
+        {
+            _repository = repository;
+            _destinoRepository = destinoRepository; 
+        }
+
+        public async Task<ExperienciaDto> CreateAsync (CreateExperienciaDto input)
+        {
+            var userId = CurrentUser.Id!.Value;
+
+            // Validar que el destino exista
+            var destinoExiste = await _destinoRepository.FindAsync(input.DestinoId);
+
+            if (destinoExiste == null)
+            {
+                throw new BusinessException("El destino especificado no existe.");
+            }
+
+            var expDuplicada = await _repository.FirstOrDefaultAsync(x =>
+                x.DestinoId == input.DestinoId &&
+                x.UserId == userId);
+
+            if (expDuplicada != null)
+            {
+                throw new AbpValidationException("Ya has creado una experiencia para este destino.");
+            }
+
+            var experiencia = new Experiencia(
+                GuidGenerator.Create(),
+                userId,
+                input.DestinoId,
+                input.Titulo,
+                input.Descripcion,
+                input.Valoracion
+            );
+
+            var experienciaCreada = await _repository.InsertAsync(experiencia, autoSave: true);
+
+            return ObjectMapper.Map<Experiencia, ExperienciaDto>(experienciaCreada);
+
+        }
+
+
+    }
+}

--- a/src/TurisGo.Application/TurisGoApplicationAutoMapperProfile.cs
+++ b/src/TurisGo.Application/TurisGoApplicationAutoMapperProfile.cs
@@ -1,6 +1,7 @@
 using AutoMapper;
 using TurisGo.Calificaciones;
 using TurisGo.Destinos;
+using TurisGo.Experiencias;
 
 namespace TurisGo;
 
@@ -19,6 +20,9 @@ public class TurisGoApplicationAutoMapperProfile : Profile
         CreateMap<Coordenada, CoordenadaDto>().ReverseMap();
 
         CreateMap<Calificacion,CalificacionDto>();
-        CreateMap<CreateCalificacionDto, Calificacion>();     
+        CreateMap<CreateCalificacionDto, Calificacion>();
+
+        CreateMap<Experiencia, ExperienciaDto>();
+        CreateMap<CreateExperienciaDto, Experiencia>();
     }
 }

--- a/src/TurisGo.Domain.Shared/Experiencias/TipoValoracion.cs
+++ b/src/TurisGo.Domain.Shared/Experiencias/TipoValoracion.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+namespace TurisGo.Experiencias
+{
+    public enum TipoValoracion
+    {
+        Positiva,        // 0   
+        Neutra,         // 1
+        Negativa       // 2
+    }
+}

--- a/src/TurisGo.Domain/Experiencias/Experiencia.cs
+++ b/src/TurisGo.Domain/Experiencias/Experiencia.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Volo.Abp.Domain.Entities.Auditing;
+using Volo.Abp.Validation;
+
+namespace TurisGo.Experiencias
+{
+    public class Experiencia : AuditedAggregateRoot<Guid>
+    {
+        public Guid UserId { get; set; }
+        public Guid DestinoId { get; set; }
+        public string Titulo { get; set; }
+        public string Descripcion { get; set; }
+        public TipoValoracion Valoracion { get; set; }
+
+        protected Experiencia () { }  // Constructor protegido para EF Core
+
+        public Experiencia (Guid id, Guid userId, Guid destinoId, string titulo, string descripcion, TipoValoracion valoracion)
+            : base(id)
+        {
+            SetUserId(userId);
+            SetDestinoId(destinoId);
+            SetTitulo(titulo);
+            SetDescripcion(descripcion);
+            SetValoracion(valoracion);
+        }
+
+        public void SetUserId(Guid userId)
+        {
+            if (userId == Guid.Empty)
+            {
+                throw new AbpValidationException("El ID del usuario no puede estar vacío.");
+            }
+
+            UserId = userId;
+        }
+
+        public void SetDestinoId (Guid destinoId)
+        {
+            if (destinoId == Guid.Empty)
+            {
+                throw new AbpValidationException("El ID del usuario no puede estar vacío.");
+            }
+
+            DestinoId = destinoId;
+        }
+
+        public void SetTitulo (string titulo)
+        {
+            if (string.IsNullOrEmpty(titulo))
+            {
+                throw new AbpValidationException("El titulo no debe ser nulo.");
+            }
+            if (titulo.Length > 100)
+            {
+                throw new AbpValidationException("El titulo no debe exceder de los 100 caracteres.");
+            }
+
+            Titulo = titulo;
+        }
+
+        public void SetDescripcion (string descripcion)
+        {
+            if (string.IsNullOrEmpty(descripcion))
+            {
+                throw new AbpValidationException("La descripcion no debe ser nula.");
+            }
+            if (descripcion.Length > 500)
+            {
+                throw new AbpValidationException("La descripcion no debe exceder los 200 caracteres.");
+            }
+
+            Descripcion = descripcion;
+        }
+
+        public void SetValoracion (TipoValoracion valoracion)
+        {
+            if (!Enum.IsDefined(typeof(TipoValoracion), valoracion))
+            {
+                throw new ArgumentException("Valoracion inválida.", nameof(valoracion));
+            }
+
+            Valoracion = valoracion;
+        }
+
+    }
+}

--- a/src/TurisGo.EntityFrameworkCore/EntityFrameworkCore/TurisGoDbContext.cs
+++ b/src/TurisGo.EntityFrameworkCore/EntityFrameworkCore/TurisGoDbContext.cs
@@ -20,6 +20,7 @@ using TurisGo.Usuarios;
 using System;
 using System.Linq;
 using System.Linq.Expressions;
+using TurisGo.Experiencias;
 
 
 namespace TurisGo.EntityFrameworkCore;
@@ -35,6 +36,8 @@ public class TurisGoDbContext : AbpDbContext<TurisGoDbContext>,
     /* Add DbSet properties for your Aggregate Roots / Entities here. */
     public DbSet<Destino> Destinos { get; set; }
     public DbSet<Calificacion> Calificaciones { get; set; }
+
+    public DbSet<Experiencia> Experiencias { get; set; }
 
     #region Entities from the modules
 
@@ -88,14 +91,6 @@ public class TurisGoDbContext : AbpDbContext<TurisGoDbContext>,
         builder.ConfigureOpenIddict();
         builder.ConfigureBlobStoring();
 
-        /* Configure your own tables/entities inside here */
-
-        //builder.Entity<YourEntity>(b =>
-        //{
-        //    b.ToTable(TurisGoConsts.DbTablePrefix + "YourEntities", TurisGoConsts.DbSchema);
-        //    b.ConfigureByConvention(); //auto configure for the base class props
-        //    //...
-        //});
 
         builder.Entity<Destino>(b =>
         {
@@ -136,6 +131,19 @@ public class TurisGoDbContext : AbpDbContext<TurisGoDbContext>,
                 (_currentUser.Id.HasValue && e.UserId == _currentUser.Id.Value));
 
         });
+
+        builder.Entity<Experiencia>(b =>
+        {
+            b.ToTable(TurisGoConsts.DbTablePrefix + "Experiencias", TurisGoConsts.DbSchema);
+            b.ConfigureByConvention();
+
+            b.Property(x => x.UserId).IsRequired();
+            b.Property(x => x.DestinoId).IsRequired();
+            b.Property(x => x.Titulo).IsRequired().HasMaxLength(100);
+            b.Property(x => x.Descripcion).IsRequired().HasMaxLength(500);
+
+        });
+
     }
 
     protected override bool ShouldFilterEntity<TEntity>(IMutableEntityType entityType)

--- a/src/TurisGo.EntityFrameworkCore/Migrations/20251205181501_Add_Experiencias.Designer.cs
+++ b/src/TurisGo.EntityFrameworkCore/Migrations/20251205181501_Add_Experiencias.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TurisGo.EntityFrameworkCore;
 using Volo.Abp.EntityFrameworkCore;
@@ -12,9 +13,11 @@ using Volo.Abp.EntityFrameworkCore;
 namespace TurisGo.Migrations
 {
     [DbContext(typeof(TurisGoDbContext))]
-    partial class TurisGoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251205181501_Add_Experiencias")]
+    partial class Add_Experiencias
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/TurisGo.EntityFrameworkCore/Migrations/20251205181501_Add_Experiencias.cs
+++ b/src/TurisGo.EntityFrameworkCore/Migrations/20251205181501_Add_Experiencias.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TurisGo.Migrations
+{
+    /// <inheritdoc />
+    public partial class Add_Experiencias : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "AppExperiencias",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    UserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    DestinoId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Titulo = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    Descripcion = table.Column<string>(type: "nvarchar(500)", maxLength: 500, nullable: false),
+                    Valoracion = table.Column<int>(type: "int", nullable: false),
+                    ExtraProperties = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    ConcurrencyStamp = table.Column<string>(type: "nvarchar(40)", maxLength: 40, nullable: false),
+                    CreationTime = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CreatorId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    LastModificationTime = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    LastModifierId = table.Column<Guid>(type: "uniqueidentifier", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AppExperiencias", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "AppExperiencias");
+        }
+    }
+}

--- a/test/TurisGo.Application.Tests/Experiencias/ExperienciaAppService_Tests.cs
+++ b/test/TurisGo.Application.Tests/Experiencias/ExperienciaAppService_Tests.cs
@@ -1,0 +1,97 @@
+﻿using Volo.Abp.Domain.Repositories;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TurisGo.Destinos;
+using Volo.Abp.Modularity;
+using Xunit;
+using Shouldly;
+using Volo.Abp;
+
+namespace TurisGo.Experiencias
+{
+    public class ExperienciaAppService_Tests<TStartupModule> : TurisGoApplicationTestBase<TStartupModule>
+        where TStartupModule : IAbpModule
+    {
+        private readonly IRepository<Experiencia, Guid> _experienciaRepository;
+        private readonly IRepository<Destino, Guid> _destinoRepository;
+        private readonly IExperienciaAppService _service;
+
+        public ExperienciaAppService_Tests()
+        {
+            _experienciaRepository = GetRequiredService<IRepository<Experiencia, Guid>>();
+            _destinoRepository = GetRequiredService<IRepository<Destino, Guid>>();
+            _service = GetRequiredService<IExperienciaAppService>();
+        }
+
+        // Helper method to create a test Destino
+        private async Task<Destino> CreateTestDestinoAsync(string nombre = "Test Destino")
+        {
+            var destino = new Destino(
+                Guid.NewGuid(),
+                nombre,
+                "Argentina",
+                1000000,
+                "https://test.com/image.jpg",
+                new Coordenada(-34.6037, -58.3816)
+            );
+
+            return await _destinoRepository.InsertAsync(destino, autoSave: true);
+        }
+
+        [Fact]
+        public async Task CreateAsync_Should_Create_Experiencia_When_Data_Is_Valid()
+        {
+            // Arrange
+            var destino = await CreateTestDestinoAsync();
+            var experiencia = new CreateExperienciaDto
+            {
+                DestinoId = destino.Id,
+                Titulo = "Una experiencia inolvidable",
+                Descripcion = "Disfruté mucho de mi visita a este destino.",
+                Valoracion = TipoValoracion.Positiva
+            };
+
+            // Act
+            var result = await _service.CreateAsync(experiencia);
+
+            // Assert
+            result.ShouldNotBeNull();
+            result.DestinoId.ShouldBe(destino.Id);
+            result.Titulo.ShouldBe(experiencia.Titulo);
+            result.Descripcion.ShouldBe(experiencia.Descripcion);
+            result.Valoracion.ShouldBe(experiencia.Valoracion);
+        }
+
+        [Fact]
+        public async Task CreateAsync_Should_Throw_Exception_When_Destino_Does_Not_Exist()
+        {
+            // Arrange
+            var destinoId = Guid.NewGuid(); // ID de destino inexistente
+            var experiencia = new CreateExperienciaDto
+            {
+                DestinoId = destinoId,
+                Titulo = "Una experiencia inolvidable",
+                Descripcion = "Disfruté mucho de mi visita a este destino.",
+                Valoracion = TipoValoracion.Positiva
+            };
+
+            // Act & Assert
+            await Should.ThrowAsync<BusinessException>(async () =>
+                {
+                    await _service.CreateAsync(experiencia);
+                });
+
+
+        }
+
+
+
+
+
+
+
+    }
+}

--- a/test/TurisGo.Domain.Tests/Experiencias/Experiencia_Tests.cs
+++ b/test/TurisGo.Domain.Tests/Experiencias/Experiencia_Tests.cs
@@ -1,0 +1,104 @@
+﻿using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Volo.Abp.Domain.Repositories;
+using Volo.Abp.Validation;
+using Xunit;
+
+namespace TurisGo.Experiencias
+{
+    public class Experiencia_Tests 
+    {
+        private readonly Guid _userId = Guid.NewGuid();
+        private readonly Guid _destinoId = Guid.NewGuid();
+    
+
+        [Fact]
+        public void Create_Should_Create_Experiencia_With_Valid_Data()
+        {
+            // Arrange
+            var id = Guid.NewGuid();
+            var titulo = "Una experiencia maravillosa";
+            var descripcion = "Disfruté mucho de mi visita a este destino.";
+
+            // Act
+            var experiencia = new Experiencia(
+                id,
+                _userId,
+                _destinoId,
+                titulo,
+                descripcion,
+                TipoValoracion.Positiva
+            );
+
+            // Assert
+            experiencia.ShouldNotBeNull();
+            experiencia.Id.ShouldBe(id);
+            experiencia.UserId.ShouldBe(_userId);
+            experiencia.DestinoId.ShouldBe(_destinoId);
+            experiencia.Titulo.ShouldBe(titulo);
+            experiencia.Descripcion.ShouldBe(descripcion);
+            experiencia.Valoracion.ShouldBe(TipoValoracion.Positiva);
+
+        }
+
+        [Fact]
+        public void Create_Should_Throw_Exception_When_UserId_Is_Empty()
+        {
+            // Act & Assert
+            Should.Throw<AbpValidationException>(() =>
+            {
+                var experiencia = new Experiencia(
+                    Guid.NewGuid(),
+                    Guid.Empty,
+                    _destinoId,
+                    "Titulo Valido",
+                    "Descripcion Valida",
+                    TipoValoracion.Positiva
+                );
+            });
+        }
+
+        [Fact]
+        public void Create_Should_Throw_Exception_When_DestinoId_Is_Empty()
+        {
+            // Act & Assert
+            Should.Throw<AbpValidationException>(() =>
+            {
+                var experiencia = new Experiencia(
+                    Guid.NewGuid(),
+                    _userId,
+                    Guid.Empty,
+                    "Titulo Valido",
+                    "Descripcion Valida",
+                    TipoValoracion.Positiva
+                );
+            });
+        }
+
+        [Fact]
+        public void Create_Should_Throw_Exception_When_Titulo_Exceeds_MaxLength()
+        {
+            // Arrange
+            var tituloLargo = new string('A', 101); // 101 caracteres
+
+            // Act & Assert
+            Should.Throw<AbpValidationException>(() =>
+            {
+                var experiencia = new Experiencia(
+                    Guid.NewGuid(),
+                    _userId,
+                    _destinoId,
+                    tituloLargo,
+                    "Descripcion Valida",
+                    TipoValoracion.Positiva
+                );
+            });
+        }
+
+
+    }
+}

--- a/test/TurisGo.EntityFrameworkCore.Tests/Experiencias/EfCoreExperienciaAppService_Test.cs
+++ b/test/TurisGo.EntityFrameworkCore.Tests/Experiencias/EfCoreExperienciaAppService_Test.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TurisGo.EntityFrameworkCore;
+using Xunit;
+
+namespace TurisGo.Experiencias
+{
+    [Collection(TurisGoTestConsts.CollectionDefinitionName)]
+    public class EfCoreExperienciaAppService_Test : ExperienciaAppService_Tests<TurisGoEntityFrameworkCoreTestModule>
+    {
+    }
+}


### PR DESCRIPTION
## Cambios realizados
- Se crearon las clases necesarias para implementar la operación.
- Solo un usuario autenticado puede crear una experiencia en un destino.
- Se realizó la migración hacia la base de datos.
- Se agregaron algunas pruebas de integración y unitarias.
- Se probó el endpoint en Swagger, resultando exitoso.

## Issue relacionado
Closes #29 