### PR TITLE
Implementación 4.3. Eliminar una experiencia propia.

### DIFF
--- a/src/TurisGo.Application.Contracts/Experiencias/IExperienciaAppService.cs
+++ b/src/TurisGo.Application.Contracts/Experiencias/IExperienciaAppService.cs
@@ -11,5 +11,7 @@ namespace TurisGo.Experiencias
     {
         Task<ExperienciaDto> CreateAsync(CreateExperienciaDto input); // 4.1. Crear una nueva experiencia de un destino.
         Task<ExperienciaDto> UpdateAsync(Guid Id, UpdateExperienciaDto input); // 4.2. Editar una experiencia propia.
+
+        Task DeleteAsync(Guid id); // 4.3. Eliminar una experiencia propia.
     }
 }

--- a/src/TurisGo.Application/Experiencias/ExperienciaAppService.cs
+++ b/src/TurisGo.Application/Experiencias/ExperienciaAppService.cs
@@ -91,6 +91,25 @@ namespace TurisGo.Experiencias
 
         }
 
+        public async Task DeleteAsync(Guid id)
+        {
+            var userId = CurrentUser.Id!.Value;
+            var experiencia = await _repository.FirstOrDefaultAsync(c => 
+                                        c.Id == id &&
+                                        c.UserId == userId);
+
+            if (experiencia == null)
+            {
+                throw new BusinessException("El ID no corresponde a ninguna experiencia propia.");
+            }
+
+            await _repository.DeleteAsync(experiencia, autoSave: true);
+
+        }
+
+        
+
+
 
 
 

--- a/test/TurisGo.Application.Tests/Experiencias/ExperienciaAppService_Tests.cs
+++ b/test/TurisGo.Application.Tests/Experiencias/ExperienciaAppService_Tests.cs
@@ -15,7 +15,7 @@ using Volo.Abp.Authorization;
 
 namespace TurisGo.Experiencias
 {
-    public class ExperienciaAppService_Tests<TStartupModule> : TurisGoApplicationTestBase<TStartupModule>
+    public abstract class ExperienciaAppService_Tests<TStartupModule> : TurisGoApplicationTestBase<TStartupModule>
         where TStartupModule : IAbpModule
     {
         private readonly IRepository<Experiencia, Guid> _experienciaRepository;
@@ -180,10 +180,30 @@ namespace TurisGo.Experiencias
             });
         }
 
+        [Fact]
+        public async Task DeleteAsync_Should_Delete_Experiencia_When_User_Is_Owner()
+        {
+            // Arrange
+            var destino = await CreateTestDestinoAsync();
+            var userId = _currentUser.Id!.Value;
+            var experiencia = new Experiencia(
+                Guid.NewGuid(),
+                userId,
+                destino.Id,
+                "Titulo a eliminar",
+                "Descripcion a eliminar",
+                TipoValoracion.Neutra
+            );
+            await _experienciaRepository.InsertAsync(experiencia, autoSave: true);
 
+            // Act
+            await _service.DeleteAsync(experiencia.Id);
 
+            // Assert
+            var experienciaInDb = await _experienciaRepository.FindAsync(experiencia.Id);
+            experienciaInDb.ShouldBeNull();
+        }
 
-
-
+        
     }
 }


### PR DESCRIPTION
## Cambios realizados
- Se implementó el método **DeleteAsync** en la sección de **ExperienciaAppService**
- Se implementó una prueba de integración y ninguna prueba unitaria ya que la lógica está en el **AppService**
- Se probó el endpoint en Swagger, obtuviendo resultados esperados.

## Issue relacionado
Closes #33  