### PR TITLE
Implementación 4.5. Filtrar experiencias por valoración (positiva / neutra / negativa)

### DIFF
--- a/src/TurisGo.Application.Contracts/Experiencias/GetExperienciasListDto.cs
+++ b/src/TurisGo.Application.Contracts/Experiencias/GetExperienciasListDto.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Volo.Abp.Application.Dtos;
+
+namespace TurisGo.Experiencias
+{
+    public class GetExperienciasListDto : PagedAndSortedResultRequestDto
+    {
+        public TipoValoracion? Valoracion { get; set; }
+    }
+}

--- a/src/TurisGo.Application.Contracts/Experiencias/IExperienciaAppService.cs
+++ b/src/TurisGo.Application.Contracts/Experiencias/IExperienciaAppService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
 
 namespace TurisGo.Experiencias
@@ -13,5 +14,6 @@ namespace TurisGo.Experiencias
         Task<ExperienciaDto> UpdateAsync(Guid Id, UpdateExperienciaDto input); // 4.2. Editar una experiencia propia.
         Task DeleteAsync(Guid id); // 4.3. Eliminar una experiencia propia.
         Task<ListarExperienciasDto> GetListExperienciasAsync(Guid destinoId); // 4.4. Listar experiencias de un destino.
+        Task<PagedResultDto<ExperienciaDto>> GetListAsync(GetExperienciasListDto input); // 4.5. Filtrar experiencias por valoración.
     }
 }

--- a/src/TurisGo.Application/Experiencias/ExperienciaAppService.cs
+++ b/src/TurisGo.Application/Experiencias/ExperienciaAppService.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Authorization;
+﻿using Volo.Abp.Application.Dtos;
+using Microsoft.AspNetCore.Authorization;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -161,8 +162,44 @@ namespace TurisGo.Experiencias
 
         }
 
+       
+        public async Task<PagedResultDto<ExperienciaDto>> GetListAsync (GetExperienciasListDto input)
+        {
 
+            var userId = CurrentUser.Id!.Value;
 
+            var queryable = await _repository.GetQueryableAsync();
+
+            var query = queryable.Where(e => e.UserId == userId);
+
+            // Filtrar por valoracion si se proporciona
+            if (input.Valoracion.HasValue)
+            {
+                query = query.Where(e => e.Valoracion == input.Valoracion.Value);
+            }
+
+            // Ordenar por fecha de creacion (mas reciente primero)
+            query = query.OrderByDescending(e => e.CreationTime);
+
+            // Obtener el total de registros
+            var totalCount = await AsyncExecuter.CountAsync(query);
+
+            // Aplicar paginacion
+            var experiencias = await AsyncExecuter.ToListAsync(
+                query
+                    .Skip(input.SkipCount)
+                    .Take(input.MaxResultCount)
+            );
+
+            // Mapear a DTOs
+            var experienciaDtos = ObjectMapper.Map<List<Experiencia>, List<ExperienciaDto>>(experiencias);
+
+            return new PagedResultDto<ExperienciaDto>(
+                totalCount,
+                experienciaDtos
+            );
+
+        }
 
 
 

--- a/test/TurisGo.Application.Tests/Experiencias/ExperienciaAppService_Tests.cs
+++ b/test/TurisGo.Application.Tests/Experiencias/ExperienciaAppService_Tests.cs
@@ -46,6 +46,24 @@ namespace TurisGo.Experiencias
             return await _destinoRepository.InsertAsync(destino, autoSave: true);
         }
 
+        // Helper method to create a test Experiencia
+        private async Task<Experiencia> CreateTestExperienciaAsync(TipoValoracion valoracion, string titulo = "Experiencia de prueba")
+        {
+            var destino = await CreateTestDestinoAsync();
+
+            var experiencia = new Experiencia(
+                Guid.NewGuid(),
+                _currentUser.Id!.Value,
+                destino.Id,
+                titulo,
+                "Descripción de la experiencia de prueba.",
+                valoracion
+            );
+
+            return await _experienciaRepository.InsertAsync(experiencia, autoSave: true);
+        }
+
+
         [Fact]
         public async Task CreateAsync_Should_Create_Experiencia_When_Data_Is_Valid()
         {
@@ -243,6 +261,97 @@ namespace TurisGo.Experiencias
             });
         }
 
-        
+        [Fact]
+        public async Task GetListAsync_Should_Return_All_Experiencias_When_No_Filter()
+        {
+            // Arrange
+            await CreateTestExperienciaAsync(TipoValoracion.Positiva, "Exp 1");
+            await CreateTestExperienciaAsync(TipoValoracion.Neutra, "Exp 2");
+            await CreateTestExperienciaAsync(TipoValoracion.Negativa, "Exp 3");
+
+            var input = new GetExperienciasListDto
+            {
+                Valoracion = null,
+                MaxResultCount = 10,
+                SkipCount = 0
+            };
+
+            // Act
+            var result = await _service.GetListAsync(input);
+
+            // Assert
+            result.TotalCount.ShouldBeGreaterThanOrEqualTo(3);
+            result.Items.Count.ShouldBeGreaterThanOrEqualTo(3);
+
+            result.Items.ShouldContain(x => x.Valoracion == TipoValoracion.Positiva);
+            result.Items.ShouldContain(x => x.Valoracion == TipoValoracion.Neutra);
+            result.Items.ShouldContain(x => x.Valoracion == TipoValoracion.Negativa);
+
+        }
+
+        [Fact]
+        public async Task GetListAsync_Should_Return_Only_Positivas_When_Filtered()
+        {
+            // Arrange
+            await CreateTestExperienciaAsync(TipoValoracion.Positiva);
+            await CreateTestExperienciaAsync(TipoValoracion.Positiva);
+            await CreateTestExperienciaAsync(TipoValoracion.Neutra);
+            await CreateTestExperienciaAsync(TipoValoracion.Negativa);
+
+            var input = new GetExperienciasListDto
+            {
+                Valoracion = TipoValoracion.Positiva, 
+                SkipCount = 0,
+                MaxResultCount = 10
+            };
+
+            // Act
+            var result = await _service.GetListAsync(input);
+
+            // Assert
+            result.TotalCount.ShouldBeGreaterThanOrEqualTo(2);
+            result.Items.ShouldAllBe(x => x.Valoracion == TipoValoracion.Positiva);
+
+            // Verificar que NO hay otros tipos
+            result.Items.ShouldNotContain(x => x.Valoracion == TipoValoracion.Neutra);
+            result.Items.ShouldNotContain(x => x.Valoracion == TipoValoracion.Negativa);
+        }
+
+        [Fact]
+        public async Task GetListAsync_Should_Only_Return_Current_User_Experiencias()
+        {
+            // Arrange
+            await CreateTestExperienciaAsync(TipoValoracion.Positiva, "Mi exp");
+
+            // Crear experiencia de otro usuario
+            var destino = await CreateTestDestinoAsync();
+            var expAjena = new Experiencia(
+                Guid.NewGuid(),
+                Guid.NewGuid(),  // Otro usuario
+                destino.Id,
+                "Experiencia ajena",
+                "No debería aparecer",
+                TipoValoracion.Positiva
+            );
+            await _experienciaRepository.InsertAsync(expAjena, autoSave: true);
+
+            var input = new GetExperienciasListDto
+            {
+                Valoracion = TipoValoracion.Positiva,
+                SkipCount = 0,
+                MaxResultCount = 10
+            };
+
+            // Act
+            var result = await _service.GetListAsync(input);
+
+            // Assert
+            result.Items.ShouldAllBe(x => x.UserId == _currentUser.Id!.Value);
+            result.Items.ShouldNotContain(x => x.Titulo == "Experiencia ajena");
+        }
+
+
+
+
     }
 }

--- a/test/TurisGo.Domain.Tests/Experiencias/Experiencia_Tests.cs
+++ b/test/TurisGo.Domain.Tests/Experiencias/Experiencia_Tests.cs
@@ -17,7 +17,7 @@ namespace TurisGo.Experiencias
 
 
         [Fact]
-        public void Create_Should_Create_Experiencia_With_Valid_Data()
+        public void Should_Create_Experiencia_With_Valid_Data()
         {
             // Arrange
             var id = Guid.NewGuid();
@@ -46,7 +46,7 @@ namespace TurisGo.Experiencias
         }
 
         [Fact]
-        public void Create_Should_Throw_Exception_When_UserId_Is_Empty()
+        public void Should_Throw_Exception_When_UserId_Is_Empty()
         {
             // Act & Assert
             Should.Throw<AbpValidationException>(() =>
@@ -63,7 +63,7 @@ namespace TurisGo.Experiencias
         }
 
         [Fact]
-        public void Create_Should_Throw_Exception_When_DestinoId_Is_Empty()
+        public void Should_Throw_Exception_When_DestinoId_Is_Empty()
         {
             // Act & Assert
             Should.Throw<AbpValidationException>(() =>
@@ -80,7 +80,7 @@ namespace TurisGo.Experiencias
         }
 
         [Fact]
-        public void Create_Should_Throw_Exception_When_Titulo_Exceeds_MaxLength()
+        public void Should_Throw_Exception_When_Titulo_Exceeds_MaxLength()
         {
             // Arrange
             var tituloLargo = new string('A', 101); // 101 caracteres
@@ -101,7 +101,7 @@ namespace TurisGo.Experiencias
 
 
         [Fact]
-        public void UpdateAsync_Should_Update_Experiencia_With_Valid_Data()
+        public void Should_Update_Experiencia_With_Valid_Data()
         {
             // Arrange
             var experiencia = new Experiencia(
@@ -134,7 +134,7 @@ namespace TurisGo.Experiencias
         }
 
         [Fact]
-        public void UpdateAsync_Should_Throw_Exception_When_Titulo_Is_Null()
+        public void Should_Throw_Exception_When_Titulo_Is_Null()
         {
             // Arrange
             var experiencia = new Experiencia(
@@ -155,7 +155,7 @@ namespace TurisGo.Experiencias
         }
 
         [Fact]
-        public void UpdateAsync_Should_Throw_Exception_When_Descripcion_Exceeds_MaxLength()
+        public void Should_Throw_Exception_When_Descripcion_Exceeds_MaxLength()
         {
             // Arrange
             var experiencia = new Experiencia(
@@ -175,44 +175,6 @@ namespace TurisGo.Experiencias
                 experiencia.SetDescripcion(descripcionLarga);
             });
 
-
-        }
-
-        [Fact]
-        public void GetListExperienciasAsync_Should_Return_List_Experiencias()
-        {
-            // Arrange
-            var destinoId = Guid.NewGuid();
-            var experiencias = new List<ExperienciaPropiaDto>
-            {
-                new ExperienciaPropiaDto
-                {
-                    NombreUsuario = "user1",
-                    Titulo = "titulo 1",
-                    Descripcion = "Descripcion 1",
-                    Valoracion = TipoValoracion.Positiva
-                },
-
-                new ExperienciaPropiaDto
-                {
-                    NombreUsuario = "user 2",
-                    Titulo = "titulo 2",
-                    Descripcion = "Descripcion 2",
-                    Valoracion = TipoValoracion.Neutra
-                }
-            };
-
-            // Act
-            var dto = new ListarExperienciasDto
-            {
-                DestinoId = destinoId,
-                Experiencias = experiencias
-            };
-
-            // Assert
-            dto.ShouldNotBeNull();
-            dto.DestinoId.ShouldBe(destinoId);
-            dto.Experiencias.Count.ShouldBe(2);
 
         }
     }


### PR DESCRIPTION
## Cambios realizados
- Se implementó la clase **GetExperienciasListDto** con solo el atributo **Valoración** para poder filtrar.
- Se creó el método **GetListAsync** en **ExperienciaAppService** para poder filtrar las experiencias de un usuario por valoración.
- Se agregaron pruebas de integración, resultando exitosas.
- Se probó el endpoint en Swagger, obteniendo los resultados esperados.

## Issue relacionado
Closes #37 