### PR TITLE
Implementación operación 1.6. Consultar perfil público de otros usuarios

### DIFF
--- a/src/TurisGo.Application.Contracts/Usuarios/IUsuarioAppService.cs
+++ b/src/TurisGo.Application.Contracts/Usuarios/IUsuarioAppService.cs
@@ -23,5 +23,8 @@ namespace TurisGo.Usuarios
 
         // 1.5. Eliminar cuenta propia
         Task EliminarCuentaPropia(EliminarCuentaDto input);
+
+        // 1.6. Obtener perfil publico de otros usuarios
+        Task<PerfilPublicoDto> ObtenerPerfilPublicoAsync(string nombreUsuario);
     }
 }

--- a/src/TurisGo.Application.Contracts/Usuarios/PerfilPublicoDto.cs
+++ b/src/TurisGo.Application.Contracts/Usuarios/PerfilPublicoDto.cs
@@ -8,7 +8,7 @@ using Volo.Abp.Application.Dtos;
 namespace TurisGo.Usuarios
 {
     // DTO para exponer el perfil público de un usuario (sin información sensible)
-    public class PerfilPublicoDto : EntityDto<Guid>
+    public class PerfilPublicoDto
     {
         public string NombreCompleto { get; set; }
         public string NombreUsuario { get; set; }

--- a/src/TurisGo.Application/Usuarios/UsuarioAppService.cs
+++ b/src/TurisGo.Application/Usuarios/UsuarioAppService.cs
@@ -412,5 +412,36 @@ namespace TurisGo.Usuarios
             }
         }
 
+        [AllowAnonymous]
+        // --------------- 1.6. Consultar perfil publico de usuario ---------------
+        public async Task<PerfilPublicoDto> ObtenerPerfilPublicoAsync(string nombreUsuario)
+        {
+            // Validar entrada
+            if (string.IsNullOrWhiteSpace(nombreUsuario))
+            {
+                throw new AbpValidationException("El nombre de usuario no puede estar vacío.");
+            }
+
+            // Buscar por nombre de usuario
+            var usuario = await _usuarioRepository
+                .FirstOrDefaultAsync(u => u.NombreUsuario == nombreUsuario);
+
+            if (usuario == null)
+            {
+                throw new EntityNotFoundException(
+                    typeof(Usuario),
+                    $"No se encontró el usuario con nombre de usuario: {nombreUsuario}"
+                );
+            }
+
+            // Verificar que el usuario esté activo
+            if (!usuario.EstaActivo)
+            {
+                throw new BusinessException("El usuario no está activo.");
+            }
+
+            return ObjectMapper.Map<Usuario, PerfilPublicoDto>(usuario);
+        }
+
     }
 }

--- a/test/TurisGo.Application.Tests/Usuarios/UsuarioAppService_Tests.cs
+++ b/test/TurisGo.Application.Tests/Usuarios/UsuarioAppService_Tests.cs
@@ -13,7 +13,7 @@ using Volo.Abp.Modularity;
 using Volo.Abp.Users;
 using Volo.Abp.Validation;
 using Xunit;
-using Volo.Abp.Authorization;
+
 
 
 namespace TurisGo.Usuarios
@@ -248,6 +248,51 @@ namespace TurisGo.Usuarios
             // Act & Assert - Sin establecer CurrentUser.Id
             await Should.ThrowAsync<EntityNotFoundException>(
                 _usuarioAppService.EliminarCuentaPropia(eliminarDto)
+            );
+        }
+
+        // ----------------- Operacion 1.6. Consultar perfil de otro usuario -----------------
+
+        [Fact]
+        public async Task ObtenerPerfilPublico_WithValidUserName_RetornPerfilPublic()
+        {
+            // Arrange
+            var input = CreateValidCrearUsuarioDto();
+            var usuario = await _usuarioAppService.RegistrarUsuarioAsync(input);
+
+            // Act
+            var perfilPublico = await _usuarioAppService
+                .ObtenerPerfilPublicoAsync(input.NombreUsuario);
+
+            // Assert
+            perfilPublico.ShouldNotBeNull();
+            perfilPublico.NombreCompleto.ShouldBe(input.NombreCompleto);
+            perfilPublico.NombreUsuario.ShouldBe(input.NombreUsuario);
+            perfilPublico.FotoPerfilUrl.ShouldBe(input.FotoPerfilUrl);
+
+        }
+
+        [Fact]
+        public async Task ObtenerPerfilPublico_ConNombreUsuarioInexistente_ThrowsEntityNotFoundException()
+        {
+            // Arrange
+            var nombreUsuarioInexistente = "usuarioquenoxiste123";
+
+            // Act & Assert
+            await Should.ThrowAsync<EntityNotFoundException>(
+                _usuarioAppService.ObtenerPerfilPublicoAsync(nombreUsuarioInexistente)
+            );
+        }
+
+        [Fact]
+        public async Task ObtenerPerfilPublico_WithEmptyUserName_ThrowsValidationException()
+        {
+            // Arrange
+            var nombreUsuarioVacio = "";
+
+            // Act & Assert
+            await Should.ThrowAsync<Abp.Runtime.Validation.AbpValidationException>(
+                _usuarioAppService.ObtenerPerfilPublicoAsync(nombreUsuarioVacio)
             );
         }
     }


### PR DESCRIPTION
## Cambios realizados

- Se implemento el método necesario para obtener el perfil publico de otros usuario (nombreUsuario, nombreCompleto, foto)
- Se agregó algunas pruebas de integración, resultando exitosas cada una de ellas.
- Se probó el endpoint en Swagger, obteniendo resultados esperados.

## Issue relacionado
Closes #49 